### PR TITLE
Make OpenGL optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ include Makefile.mk
 all: libs $(PLUGINS) gen
 
 libs:
+ifeq ($(HAVE_DGL),true)
 	$(MAKE) -C dpf/dgl
+endif
 
 gen: $(PLUGINS) dpf/utils/lv2_ttl_generator
 	@$(CURDIR)/dpf/utils/generate-ttl.sh
@@ -63,7 +65,9 @@ clean:
 	for plugin in $(PLUGINS); do \
 		$(MAKE) -C plugins/"$$plugin" clean; \
 	done
+ifeq ($(HAVE_DGL),true)
 	$(MAKE) clean -C dpf/dgl
+endif
 	$(MAKE) clean -C dpf/utils/lv2-ttl-generator
 
 # --------------------------------------------------------------


### PR DESCRIPTION
UIs are not required for building the plugins, so don't try to build GL libs if OpenGL is not available.
This is required for MOD builds, as X11/GL is not present there.
Also nice for those that run headless.

PS: The makefiles in this repo already handle the case of plugins not having UIs.