### PR TITLE
Change the attack release behavior of compressor plugins ...

### DIFF
--- a/plugins/ZaMultiComp/ZaMultiCompPlugin.cpp
+++ b/plugins/ZaMultiComp/ZaMultiCompPlugin.cpp
@@ -791,7 +791,7 @@ void ZaMultiCompPlugin::run_comp(int k, float in, float *out)
         float cdb=0.f;
         float Lgain = 1.f;
         float Lxg, Lyg;
-        float Lxl, Lyl, Ly1;
+        float Lxl, Lyl;
 
         Lyg = 0.f;
 	in = sanitize_denormal(in);
@@ -811,12 +811,15 @@ void ZaMultiCompPlugin::run_comp(int k, float in, float *out)
 
         Lxl = Lxg - Lyg;
 
-        old_y1[k] = sanitize_denormal(old_y1[k]);
-        old_yl[k] = sanitize_denormal(old_yl[k]);
+	old_yl[k] = sanitize_denormal(old_yl[k]);
 
-        Ly1 = fmaxf(Lxl, release_coeff * old_y1[k]+(1.f-release_coeff)*Lxl);
-        Lyl = attack_coeff * old_yl[k]+(1.f-attack_coeff)*Ly1;
-        Ly1 = sanitize_denormal(Ly1);
+	if (Lxl < old_yl[k]) {
+		Lyl = release_coeff * old_yl[k] + (1.f-release_coeff)*Lxl;
+	} else if (Lxl > old_yl[k]) {
+		Lyl = attack_coeff * old_yl[k]+(1.f-attack_coeff)*Lxl;
+	} else {
+		Lyl = Lxl;
+	}
         Lyl = sanitize_denormal(Lyl);
 
         cdb = -Lyl;
@@ -827,7 +830,6 @@ void ZaMultiCompPlugin::run_comp(int k, float in, float *out)
 	*out = in * Lgain;
 
         old_yl[k] = Lyl;
-        old_y1[k] = Ly1;
         old_yg[k] = Lyg;
 }
 

--- a/plugins/ZaMultiComp/ZaMultiCompPlugin.cpp
+++ b/plugins/ZaMultiComp/ZaMultiCompPlugin.cpp
@@ -814,7 +814,7 @@ void ZaMultiCompPlugin::run_comp(int k, float in, float *out)
 	old_yl[k] = sanitize_denormal(old_yl[k]);
 
 	if (Lxl < old_yl[k]) {
-		Lyl = release_coeff * old_yl[k] + (1.f-release_coeff)*Lxl;
+		Lyl = release_coeff * old_yl[k]+(1.f-release_coeff)*Lxl;
 	} else if (Lxl > old_yl[k]) {
 		Lyl = attack_coeff * old_yl[k]+(1.f-attack_coeff)*Lxl;
 	} else {

--- a/plugins/ZaMultiCompX2/ZaMultiCompX2Plugin.cpp
+++ b/plugins/ZaMultiCompX2/ZaMultiCompX2Plugin.cpp
@@ -811,8 +811,8 @@ void ZaMultiCompX2Plugin::run_comp(int k, float inL, float inR, float *outL, flo
         float Rgain = 1.f;
         float Lxg, Lyg;
         float Rxg, Ryg;
-        float Lxl, Lyl, Ly1;
-        float Rxl, Ryl, Ry1;
+        float Lxl, Lyl;
+        float Rxl, Ryl;
 
         Lyg = Ryg = 0.f;
 	inL = sanitize_denormal(inL);
@@ -850,22 +850,29 @@ void ZaMultiCompX2Plugin::run_comp(int k, float inL, float inR, float *outL, flo
                 Lxl = Rxl = (Lxg - Lyg + Rxg - Ryg) / 2.f;
         }
 
-        old_y1[0][k] = sanitize_denormal(old_y1[0][k]);
-        old_y1[1][k] = sanitize_denormal(old_y1[1][k]);
         old_yl[0][k] = sanitize_denormal(old_yl[0][k]);
         old_yl[1][k] = sanitize_denormal(old_yl[1][k]);
 
-        Ly1 = fmaxf(Lxl, release_coeff * old_y1[0][k]+(1.f-release_coeff)*Lxl);
-        Lyl = attack_coeff * old_yl[0][k]+(1.f-attack_coeff)*Ly1;
-        Ly1 = sanitize_denormal(Ly1);
+
+	if (Lxl < old_yl[0][k]) {
+		Lyl = release_coeff * old_yl[0][k] + (1.f-release_coeff)*Lxl;
+	} else if (Lxl > old_yl[0][k]) {
+		Lyl = attack_coeff * old_yl[0][k]+(1.f-attack_coeff)*Lxl;
+	} else {
+		Lyl = Lxl;
+	}
         Lyl = sanitize_denormal(Lyl);
 
         cdb = -Lyl;
         Lgain = from_dB(cdb);
 
-        Ry1 = fmaxf(Rxl, release_coeff * old_y1[1][k]+(1.f-release_coeff)*Rxl);
-        Ryl = attack_coeff * old_yl[1][k]+(1.f-attack_coeff)*Ry1;
-        Ry1 = sanitize_denormal(Ry1);
+	if (Rxl < old_yl[0][k]) {
+		Ryl = release_coeff * old_yl[0][k] + (1.f-release_coeff)*Rxl;
+	} else if (Rxl > old_yl[0][k]) {
+		Ryl = attack_coeff * old_yl[0][k]+(1.f-attack_coeff)*Rxl;
+	} else {
+		Ryl = Rxl;
+	}
         Ryl = sanitize_denormal(Ryl);
 
         cdb = -Ryl;
@@ -881,8 +888,6 @@ void ZaMultiCompX2Plugin::run_comp(int k, float inL, float inR, float *outL, flo
 
         old_yl[0][k] = Lyl;
         old_yl[1][k] = Ryl;
-        old_y1[0][k] = Ly1;
-        old_y1[1][k] = Ry1;
         old_yg[0][k] = Lyg;
         old_yg[1][k] = Ryg;
 }

--- a/plugins/ZaMultiCompX2/ZaMultiCompX2Plugin.cpp
+++ b/plugins/ZaMultiCompX2/ZaMultiCompX2Plugin.cpp
@@ -866,10 +866,10 @@ void ZaMultiCompX2Plugin::run_comp(int k, float inL, float inR, float *outL, flo
         cdb = -Lyl;
         Lgain = from_dB(cdb);
 
-	if (Rxl < old_yl[0][k]) {
-		Ryl = release_coeff * old_yl[0][k] + (1.f-release_coeff)*Rxl;
-	} else if (Rxl > old_yl[0][k]) {
-		Ryl = attack_coeff * old_yl[0][k]+(1.f-attack_coeff)*Rxl;
+	if (Rxl < old_yl[1][k]) {
+		Ryl = release_coeff * old_yl[1][k] + (1.f-release_coeff)*Rxl;
+	} else if (Rxl > old_yl[1][k]) {
+		Ryl = attack_coeff * old_yl[1][k]+(1.f-attack_coeff)*Rxl;
 	} else {
 		Ryl = Rxl;
 	}

--- a/plugins/ZaMultiCompX2/ZaMultiCompX2Plugin.cpp
+++ b/plugins/ZaMultiCompX2/ZaMultiCompX2Plugin.cpp
@@ -855,7 +855,7 @@ void ZaMultiCompX2Plugin::run_comp(int k, float inL, float inR, float *outL, flo
 
 
 	if (Lxl < old_yl[0][k]) {
-		Lyl = release_coeff * old_yl[0][k] + (1.f-release_coeff)*Lxl;
+		Lyl = release_coeff * old_yl[0][k]+(1.f-release_coeff)*Lxl;
 	} else if (Lxl > old_yl[0][k]) {
 		Lyl = attack_coeff * old_yl[0][k]+(1.f-attack_coeff)*Lxl;
 	} else {
@@ -867,7 +867,7 @@ void ZaMultiCompX2Plugin::run_comp(int k, float inL, float inR, float *outL, flo
         Lgain = from_dB(cdb);
 
 	if (Rxl < old_yl[1][k]) {
-		Ryl = release_coeff * old_yl[1][k] + (1.f-release_coeff)*Rxl;
+		Ryl = release_coeff * old_yl[1][k]+(1.f-release_coeff)*Rxl;
 	} else if (Rxl > old_yl[1][k]) {
 		Ryl = attack_coeff * old_yl[1][k]+(1.f-attack_coeff)*Rxl;
 	} else {

--- a/plugins/ZamComp/ZamCompPlugin.cpp
+++ b/plugins/ZamComp/ZamCompPlugin.cpp
@@ -343,7 +343,7 @@ void ZamCompPlugin::run(const float** inputs, float** outputs, uint32_t frames)
                 oldL_yl = sanitize_denormal(oldL_yl);
 
 		if (Lxl < oldL_yl) {
-			Lyl = release_coeff * oldL_yl + (1.f-release_coeff)*Lxl;
+			Lyl = release_coeff * oldL_yl+(1.f-release_coeff)*Lxl;
 		} else if (Lxl > oldL_yl) {
 			Lyl = attack_coeff * oldL_yl+(1.f-attack_coeff)*Lxl;
 		} else {

--- a/plugins/ZamComp/ZamCompPlugin.cpp
+++ b/plugins/ZamComp/ZamCompPlugin.cpp
@@ -300,7 +300,7 @@ void ZamCompPlugin::run(const float** inputs, float** outputs, uint32_t frames)
 	float max = 0.f;
 	float lgaininp = 0.f;
 	float Lgain = 1.f;
-        float Lxg, Lxl, Lyg, Lyl, Ly1;
+        float Lxg, Lxl, Lyg, Lyl;
         float checkwidth = 0.f;
 	bool usesidechain = (sidechain < 0.5) ? false : true;
 	uint32_t i;
@@ -340,11 +340,15 @@ void ZamCompPlugin::run(const float** inputs, float** outputs, uint32_t frames)
 
                 Lxl = Lxg - Lyg;
 
-                oldL_y1 = sanitize_denormal(oldL_y1);
                 oldL_yl = sanitize_denormal(oldL_yl);
-                Ly1 = fmaxf(Lxl, release_coeff * oldL_y1+(1.f-release_coeff)*Lxl);
-		Lyl = attack_coeff * oldL_yl+(1.f-attack_coeff)*Ly1;
-                Ly1 = sanitize_denormal(Ly1);
+
+		if (Lxl < oldL_yl) {
+			Lyl = release_coeff * oldL_yl + (1.f-release_coeff)*Lxl;
+		} else if (Lxl > oldL_yl) {
+			Lyl = attack_coeff * oldL_yl+(1.f-attack_coeff)*Lxl;
+		} else {
+			Lyl = Lxl;
+		}
                 Lyl = sanitize_denormal(Lyl);
 
                 cdb = -Lyl;
@@ -358,11 +362,10 @@ void ZamCompPlugin::run(const float** inputs, float** outputs, uint32_t frames)
 		max = (fabsf(outputs[0][i]) > max) ? fabsf(outputs[0][i]) : sanitize_denormal(max);
 
                 oldL_yl = Lyl;
-                oldL_y1 = Ly1;
                 oldL_yg = Lyg;
         }
 	outlevel = (max == 0.f) ? -45.f : to_dB(max); // relative to - thresdb;
-    }
+}
 
 // -----------------------------------------------------------------------
 

--- a/plugins/ZamCompX2/ZamCompX2Plugin.cpp
+++ b/plugins/ZamCompX2/ZamCompX2Plugin.cpp
@@ -395,7 +395,7 @@ void ZamCompX2Plugin::run(const float** inputs, float** outputs, uint32_t frames
 
                 oldL_yl = sanitize_denormal(oldL_yl);
 		if (Lxl < oldL_yl) {
-			Lyl = release_coeff * oldL_yl + (1.f-release_coeff)*Lxl;
+			Lyl = release_coeff * oldL_yl+(1.f-release_coeff)*Lxl;
 		} else if (Lxl > oldL_yl) {
 			Lyl = attack_coeff * oldL_yl+(1.f-attack_coeff)*Lxl;
 		} else {
@@ -410,7 +410,7 @@ void ZamCompX2Plugin::run(const float** inputs, float** outputs, uint32_t frames
 
                 oldR_y1 = sanitize_denormal(oldR_y1);
 		if (Rxl < oldR_yl) {
-			Ryl = release_coeff * oldR_yl + (1.f-release_coeff)*Rxl;
+			Ryl = release_coeff * oldR_yl+(1.f-release_coeff)*Rxl;
 		} else if (Rxl > oldR_yl) {
 			Ryl = attack_coeff * oldR_yl+(1.f-attack_coeff)*Rxl;
 		} else {


### PR DESCRIPTION
... so that the attack does no longer influence the release.

Before this a setting with a low release time and a high attack time made the
compressor also release slowly (according to the attack parameter). This commit
changes this behavior so that the attack parameter only affects the attack
without affecting the release.

This issue also affects the a-comp plugin in Ardour. A report with a more detailed description has been filed there: http://tracker.ardour.org/view.php?id=7439