### PR TITLE
Allow using system provided zita convolver library

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -85,6 +85,14 @@ ifeq ($(LINUX),true)
 HAVE_DGL   = $(shell pkg-config --exists gl x11 && echo true)
 HAVE_JACK  = $(shell pkg-config --exists jack   && echo true)
 HAVE_LIBLO = $(shell pkg-config --exists liblo  && echo true)
+
+# Allow to use system provided libs
+ifeq ($(USE_SYSTEM_LIBS),1)
+HAVE_ZITA_CONVOLVER = true
+ZITA_CONVOLVER_LIBS = -lzita-convolver
+export HAVE_ZITA_CONVOLVER
+endif
+
 endif
 
 ifeq ($(MACOS),true)

--- a/plugins/ZamHeadX2/Makefile
+++ b/plugins/ZamHeadX2/Makefile
@@ -12,8 +12,11 @@ NAME = ZamHeadX2
 # --------------------------------------------------------------
 # Files to build
 
-OBJS_DSP = \
-	../../lib/zita-convolver-3.1.0/zita-convolver.cpp.o \
+ifneq ($(HAVE_ZITA_CONVOLVER),true)
+OBJS_DSP = ../../lib/zita-convolver-3.1.0/zita-convolver.cpp.o
+endif
+
+OBJS_DSP += \
 	convolution.cpp.o \
 	ZamHeadX2Plugin.cpp.o
 
@@ -36,6 +39,11 @@ ifeq ($(HAVE_DGL),true)
 TARGETS += lv2_sep
 else
 TARGETS += lv2_dsp
+endif
+
+ifeq ($(HAVE_ZITA_CONVOLVER),true)
+BASE_FLAGS += -DHAVE_ZITA_CONVOLVER
+LINK_FLAGS += $(ZITA_CONVOLVER_LIBS)
 endif
 
 TARGETS += vst

--- a/plugins/ZamHeadX2/convolution.cpp
+++ b/plugins/ZamHeadX2/convolution.cpp
@@ -42,7 +42,6 @@
 #include <pthread.h>
 #include <assert.h>
 
-#include "../../lib/zita-convolver-3.1.0/zita-convolver.h"
 #include <samplerate.h>
 #include "convolution.hpp"
 

--- a/plugins/ZamHeadX2/convolution.hpp
+++ b/plugins/ZamHeadX2/convolution.hpp
@@ -19,7 +19,11 @@
 #ifndef CONVOLUTION_H_
 #define CONVOLUTION_H_
 
+#ifdef HAVE_ZITA_CONVOLVER
+#include "zita-convolver.h"
+#else
 #include "../../lib/zita-convolver-3.1.0/zita-convolver.h"
+#endif
 
 #define MAX_CHANNEL_MAPS (4)
 #define VERBOSE_printf(x, ...)

--- a/plugins/ZamVerb/Makefile
+++ b/plugins/ZamVerb/Makefile
@@ -15,8 +15,11 @@ NAME = ZamVerb
 OBJS_DSP = \
 	ZamVerbPlugin.cpp.o \
 	ZamVerbImpulses.cpp.o \
-	convolution.cpp.o \
-	../../lib/zita-convolver-3.1.0/zita-convolver.cpp.o
+	convolution.cpp.o
+
+ifneq ($(HAVE_ZITA_CONVOLVER),true)
+OBJS_DSP += ../../lib/zita-convolver-3.1.0/zita-convolver.cpp.o
+endif
 
 OBJS_UI  = \
 	ZamVerbArtwork.cpp.o \
@@ -37,6 +40,11 @@ ifeq ($(HAVE_DGL),true)
 TARGETS += lv2_sep
 else
 TARGETS += lv2_dsp
+endif
+
+ifeq ($(HAVE_ZITA_CONVOLVER),true)
+BASE_FLAGS += -DHAVE_ZITA_CONVOLVER
+LINK_FLAGS += $(ZITA_CONVOLVER_LIBS)
 endif
 
 TARGETS += vst

--- a/plugins/ZamVerb/convolution.cpp
+++ b/plugins/ZamVerb/convolution.cpp
@@ -42,7 +42,6 @@
 #include <pthread.h>
 #include <assert.h>
 
-#include "../../lib/zita-convolver-3.1.0/zita-convolver.h"
 #include <samplerate.h>
 #include "convolution.hpp"
 #include "ZamVerbImpulses.hpp"

--- a/plugins/ZamVerb/convolution.hpp
+++ b/plugins/ZamVerb/convolution.hpp
@@ -19,7 +19,11 @@
 #ifndef CONVOLUTION_H_
 #define CONVOLUTION_H_
 
+#ifdef HAVE_ZITA_CONVOLVER
+#include "zita-convolver.h"
+#else
 #include "../../lib/zita-convolver-3.1.0/zita-convolver.h"
+#endif
 
 #define MAX_CHANNEL_MAPS (4)
 #define VERBOSE_printf(x, ...)


### PR DESCRIPTION
Packaging for many distributions requires unbundling of system libraries from programs.
This PR allows to unbundle zita convolver when you add USE_SYSTEM_LIBS=1 to the make command.
It keeps default behaviour otherwise.