### PR TITLE
Add flags for libsamplerate in ZamSFZ's Makefile

### DIFF
--- a/plugins/ZamSFZ/Makefile
+++ b/plugins/ZamSFZ/Makefile
@@ -29,8 +29,8 @@ include ../../dpf/Makefile.plugins.mk
 # --------------------------------------------------------------
 # Extra flags
 
-BASE_FLAGS += $(shell pkg-config --cflags sndfile rubberband)
-LINK_FLAGS += $(shell pkg-config --libs sndfile rubberband)
+BASE_FLAGS += $(shell pkg-config --cflags sndfile rubberband samplerate)
+LINK_FLAGS += $(shell pkg-config --libs sndfile rubberband samplerate)
 
 # --------------------------------------------------------------
 # Enable all possible plugin types


### PR DESCRIPTION
This allows building ZamSFZ with the new Makefiles. I know this plugin is not considered "important", but it's a simple fix.