### PR TITLE
Use https for git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dpf"]
 	path = dpf
-	url = git://github.com/DISTRHO/DPF
+	url = https://github.com/DISTRHO/DPF


### PR DESCRIPTION
This fixes cloning with submodules
See https://github.blog/2021-09-01-improving-git-protocol-security-github/