### PR TITLE
Set initial/default UI size for ZamAutoSat, enable auto-scaling

### DIFF
--- a/plugins/ZamAutoSat/DistrhoPluginInfo.h
+++ b/plugins/ZamAutoSat/DistrhoPluginInfo.h
@@ -18,6 +18,8 @@
 #ifndef DISTRHO_PLUGIN_INFO_H_INCLUDED
 #define DISTRHO_PLUGIN_INFO_H_INCLUDED
 
+#include "ZamAutoSatArtwork.hpp"
+
 #define DISTRHO_PLUGIN_BRAND "ZamAudio"
 #define DISTRHO_PLUGIN_NAME  "ZamAutoSat"
 
@@ -32,6 +34,9 @@
 #define DISTRHO_PLUGIN_WANT_STATE    0
 #define DISTRHO_PLUGIN_WANT_TIMEPOS  0
 #define DISTRHO_PLUGIN_IS_RT_SAFE    1
+
+#define DISTRHO_UI_DEFAULT_WIDTH  ZamAutoSatArtwork::zamautosatWidth
+#define DISTRHO_UI_DEFAULT_HEIGHT ZamAutoSatArtwork::zamautosatHeight
 
 #define DISTRHO_PLUGIN_URI             "urn:zamaudio:ZamAutoSat"
 #define DISTRHO_PLUGIN_LV2_CATEGORY    "lv2:DynamicsPlugin"

--- a/plugins/ZamAutoSat/ZamAutoSatUI.cpp
+++ b/plugins/ZamAutoSat/ZamAutoSatUI.cpp
@@ -22,13 +22,10 @@ START_NAMESPACE_DISTRHO
 // -----------------------------------------------------------------------
 
 ZamAutoSatUI::ZamAutoSatUI()
-    : UI()
+    : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT, true)
 {
-    setSize(ZamAutoSatArtwork::zamautosatWidth, ZamAutoSatArtwork::zamautosatHeight);
-
     // background
     fImgBackground = Image(ZamAutoSatArtwork::zamautosatData, ZamAutoSatArtwork::zamautosatWidth, ZamAutoSatArtwork::zamautosatHeight, kImageFormatBGR);
-
 }
 
 ZamAutoSatUI::~ZamAutoSatUI()

--- a/plugins/ZamAutoSat/ZamAutoSatUI.hpp
+++ b/plugins/ZamAutoSat/ZamAutoSatUI.hpp
@@ -22,7 +22,6 @@
 
 #include "Image.hpp"
 
-#include "ZamAutoSatArtwork.hpp"
 #include "ZamAutoSatPlugin.hpp"
 
 using DGL::Image;


### PR DESCRIPTION
This PR enables a new feature of DPF that allows to skip an intermediary UI just to know its initial size, needed for a few hosts. When those macros are enabled the intermediary UI is skipped and the macro values are returned directly.

As an extra, the 3rd argument for the UI subclass constructor is in place and set as `true`.
This enables auto-scaling, which will make the UI render bigger together with host/system scale factor. It will look blurry, but have the proper size.
Integrating DPF with SVGs will come at a later date, to get scalable UIs.

I did this for 1 plugin to show you the procedure, please do the same for the other plugins in your collection, thanks!