### PR TITLE
Dynamic buffer size and sample rate changes

### DIFF
--- a/plugins/ZamChild670/ZamChild670Plugin.cpp
+++ b/plugins/ZamChild670/ZamChild670Plugin.cpp
@@ -197,6 +197,13 @@ void ZamChild670Plugin::run(const float** inputs, float** outputs, uint32_t fram
 	
 	zamchild->process(inputs, outputs, (ulong)frames);
 }
+
+void ZamChild670Plugin::sampleRateChanged(double newSampleRate)
+{
+	delete zamchild;
+	zamchild = new Wavechild670(newSampleRate, *params);
+}
+
 // -----------------------------------------------------------------------
 
 Plugin* createPlugin()

--- a/plugins/ZamChild670/ZamChild670Plugin.hpp
+++ b/plugins/ZamChild670/ZamChild670Plugin.hpp
@@ -115,6 +115,7 @@ protected:
 
     void activate() override;
     void run(const float** inputs, float** outputs, uint32_t frames) override;
+    void sampleRateChanged(double newSampleRate) override;
 
     // -------------------------------------------------------------------
 

--- a/plugins/ZamGEQ31/ZamGEQ31Plugin.cpp
+++ b/plugins/ZamGEQ31/ZamGEQ31Plugin.cpp
@@ -670,11 +670,6 @@ void ZamGEQ31Plugin::loadProgram(uint32_t index)
     omegaU[28] = 22400.;
 
     master = 0.f;
-    float srate = getSampleRate();
-    for (i = 0; i < 29; ++i) {
-        geq(i, srate, 0.);
-        gainold[i] = 0.;
-    }
 
     /* reset filter values */
     activate();
@@ -686,6 +681,11 @@ void ZamGEQ31Plugin::loadProgram(uint32_t index)
 void ZamGEQ31Plugin::activate()
 {
     int i, j;
+    float srate = getSampleRate();
+    for (i = 0; i < 29; ++i) {
+        geq(i, srate, gain[i]);
+        gainold[i] = gain[i];
+    }
     for (i = 0; i < 29; i++) {
         for (j = 0; j < 21; j++) {
             w11[i][j] = 0.;

--- a/plugins/ZamHeadX2/ZamHeadX2Plugin.cpp
+++ b/plugins/ZamHeadX2/ZamHeadX2Plugin.cpp
@@ -212,8 +212,10 @@ void ZamHeadX2Plugin::run(const float** inputs, float** outputs, uint32_t frames
 	active = swap;
 
 	if (!signal) {
-		memcpy(outputs[0], inputs[0], frames * sizeof(float));
-		memcpy(outputs[1], inputs[1], frames * sizeof(float));
+		if (outputs[0] != inputs[0])
+			memcpy(outputs[0], inputs[0], frames * sizeof(float));
+		if (outputs[1] != inputs[1])
+			memcpy(outputs[1], inputs[1], frames * sizeof(float));
 		return;
 	}
 
@@ -227,8 +229,10 @@ void ZamHeadX2Plugin::run(const float** inputs, float** outputs, uint32_t frames
  
 	nprocessed = clv[active]->clv_convolve(tmpins, tmpouts, 2, 2, frames, from_dB(6.0));
 	if (nprocessed <= 0) {
-		memcpy(outputs[0], inputs[0], frames * sizeof(float));
-		memcpy(outputs[1], inputs[1], frames * sizeof(float));
+		if (outputs[0] != inputs[0])
+			memcpy(outputs[0], inputs[0], frames * sizeof(float));
+		if (outputs[1] != inputs[1])
+			memcpy(outputs[1], inputs[1], frames * sizeof(float));
 	} else {
 		memcpy(outputs[0], tmpouts[0], frames * sizeof(float));
 		memcpy(outputs[1], tmpouts[1], frames * sizeof(float));

--- a/plugins/ZamHeadX2/ZamHeadX2Plugin.cpp
+++ b/plugins/ZamHeadX2/ZamHeadX2Plugin.cpp
@@ -235,6 +235,16 @@ void ZamHeadX2Plugin::run(const float** inputs, float** outputs, uint32_t frames
 	}
 }
 
+void ZamHeadX2Plugin::bufferSizeChanged(uint32_t)
+{
+	reload();
+}
+
+void ZamHeadX2Plugin::sampleRateChanged(double)
+{
+	reload();
+}
+
 // -----------------------------------------------------------------------
 
 Plugin* createPlugin()

--- a/plugins/ZamHeadX2/ZamHeadX2Plugin.hpp
+++ b/plugins/ZamHeadX2/ZamHeadX2Plugin.hpp
@@ -114,6 +114,9 @@ protected:
     void activate() override;
     void deactivate() override;
     void run(const float** inputs, float** outputs, uint32_t frames) override;
+    void bufferSizeChanged(uint32_t newBufferSize) override;
+    void sampleRateChanged(double newSampleRate) override;
+
     void pushsample(float* buf, float val, int i, uint32_t maxframes);
     float getsample(float* buf, int i, uint32_t maxframes);
 

--- a/plugins/ZamNoise/DistrhoPluginInfo.h
+++ b/plugins/ZamNoise/DistrhoPluginInfo.h
@@ -18,6 +18,8 @@
 #ifndef DISTRHO_PLUGIN_INFO_H_INCLUDED
 #define DISTRHO_PLUGIN_INFO_H_INCLUDED
 
+#include "ZamNoiseArtwork.hpp"
+
 #define DISTRHO_PLUGIN_BRAND "ZamAudio"
 #define DISTRHO_PLUGIN_NAME  "ZamNoise"
 
@@ -32,6 +34,10 @@
 #define DISTRHO_PLUGIN_WANT_STATE    0
 #define DISTRHO_PLUGIN_WANT_TIMEPOS  0
 
-#define DISTRHO_PLUGIN_URI "urn:zamaudio:ZamNoise"
+#define DISTRHO_UI_DEFAULT_WIDTH     ZamNoiseArtwork::zamnoiseWidth
+#define DISTRHO_UI_DEFAULT_HEIGHT    ZamNoiseArtwork::zamnoiseHeight
+
+#define DISTRHO_PLUGIN_URI     "urn:zamaudio:ZamNoise"
+#define DISTRHO_PLUGIN_CLAP_ID "com.zamaudio.ZamNoise"
 
 #endif // DISTRHO_PLUGIN_INFO_H_INCLUDED

--- a/plugins/ZamNoise/Makefile
+++ b/plugins/ZamNoise/Makefile
@@ -25,6 +25,9 @@ FILES_UI  = \
 
 include ../../dpf/Makefile.plugins.mk
 
+BASE_FLAGS += $(shell pkg-config --cflags fftw3f)
+LINK_FLAGS += $(shell pkg-config --libs fftw3f)
+
 # --------------------------------------------------------------
 # Enable all possible plugin types
 
@@ -33,6 +36,7 @@ TARGETS += ladspa
 TARGETS += lv2_sep
 TARGETS += vst2
 TARGETS += vst3
+TARGETS += clap
 
 all: $(TARGETS)
 

--- a/plugins/ZamNoise/ZamNoisePlugin.cpp
+++ b/plugins/ZamNoise/ZamNoisePlugin.cpp
@@ -139,6 +139,14 @@ void ZamNoisePlugin::run(const float** inputs, float** outputs, uint32_t frames)
 	zamnoise->process(inputs[0], outputs[0], buffer.cbi, frames, (int)noisetoggle);
 }
 
+void ZamNoisePlugin::sampleRateChanged(double newSampleRate)
+{
+	free(buffer.cbi);
+	delete zamnoise;
+	ZamNoisePlugin::init(newSampleRate);
+	zamnoise = new Denoise(newSampleRate);
+}
+
 // -----------------------------------------------------------------------
 
 Plugin* createPlugin()

--- a/plugins/ZamNoise/ZamNoisePlugin.hpp
+++ b/plugins/ZamNoise/ZamNoisePlugin.hpp
@@ -99,6 +99,7 @@ protected:
     void activate() override;
     void deactivate() override;
     void run(const float** inputs, float** outputs, uint32_t frames) override;
+    void sampleRateChanged(double newSampleRate) override;
 
     // -------------------------------------------------------------------
 	float noisetoggle;

--- a/plugins/ZamNoise/ZamNoiseUI.cpp
+++ b/plugins/ZamNoise/ZamNoiseUI.cpp
@@ -23,10 +23,8 @@ START_NAMESPACE_DISTRHO
 // -----------------------------------------------------------------------
 
 ZamNoiseUI::ZamNoiseUI()
-    : UI()
+    : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT, true)
 {
-    setSize(ZamNoiseArtwork::zamnoiseWidth,  ZamNoiseArtwork::zamnoiseHeight);
-
     // background
     fImgBackground = Image(ZamNoiseArtwork::zamnoiseData, ZamNoiseArtwork::zamnoiseWidth, ZamNoiseArtwork::zamnoiseHeight, kImageFormatBGR);
 
@@ -35,10 +33,11 @@ ZamNoiseUI::ZamNoiseUI()
     Image toggleoffImage(ZamNoiseArtwork::toggleoffData, ZamNoiseArtwork::toggleoffWidth, ZamNoiseArtwork::toggleoffHeight);
 
     // toggle
-    fToggleNoise = new ImageToggle(this, toggleonImage, toggleoffImage);
+    fToggleNoise = new ImageButton(this, toggleonImage, toggleoffImage);
     fToggleNoise->setAbsolutePos(30, 30);
     fToggleNoise->setCallback(this);
-    fToggleNoise->setValue(0.f);
+    fToggleNoise->setCheckable(true);
+    fToggleNoise->setChecked(false, false);
 
     programLoaded(0);
 }
@@ -52,12 +51,12 @@ ZamNoiseUI::~ZamNoiseUI()
 
 void ZamNoiseUI::parameterChanged(uint32_t index, float value)
 {
-        switch (index)
-        {
-        case ZamNoisePlugin::paramNoiseToggle:
-                fToggleNoise->setValue(value);
-                break;
-        }
+    switch (index)
+    {
+    case ZamNoisePlugin::paramNoiseToggle:
+        fToggleNoise->setChecked(value > 0.5f, false);
+        break;
+    }
 }
 
 
@@ -66,14 +65,12 @@ void ZamNoiseUI::programLoaded(uint32_t index)
     if (index != 0)
         return;
 
-    fToggleNoise->setValue(0.0f);
+    fToggleNoise->setChecked(false, false);
 }
 
-void ZamNoiseUI::imageToggleClicked(ImageToggle*, int)
+void ZamNoiseUI::imageButtonClicked(ImageButton*, int)
 {
-        float toggle = fToggleNoise->getValue();
-        fToggleNoise->setValue(toggle);
-        setParameterValue(ZamNoisePlugin::paramNoiseToggle, toggle);
+    setParameterValue(ZamNoisePlugin::paramNoiseToggle, fToggleNoise->isChecked() ? 1.f : 0.f);
 }
 
 
@@ -81,7 +78,8 @@ void ZamNoiseUI::imageToggleClicked(ImageToggle*, int)
 
 void ZamNoiseUI::onDisplay()
 {
-    fImgBackground.draw();
+    const GraphicsContext& context(getGraphicsContext());
+    fImgBackground.draw(context);
 }
 
 // -----------------------------------------------------------------------

--- a/plugins/ZamNoise/ZamNoiseUI.hpp
+++ b/plugins/ZamNoise/ZamNoiseUI.hpp
@@ -21,20 +21,19 @@
 #include "DistrhoUI.hpp"
 
 #include "Image.hpp"
-#include "ImageToggle.hpp"
+#include "ImageWidgets.hpp"
 
-#include "ZamNoiseArtwork.hpp"
 #include "ZamNoisePlugin.hpp"
 
 using DGL::Image;
-using DGL::ImageToggle;
+using DGL::ImageButton;
 
 START_NAMESPACE_DISTRHO
 
 // -----------------------------------------------------------------------
 
 class ZamNoiseUI : public UI,
-		public ImageToggle::Callback
+		public ImageButton::Callback
 {
 public:
     ZamNoiseUI();
@@ -49,13 +48,13 @@ protected:
 
     // -------------------------------------------------------------------
 
-    void imageToggleClicked(ImageToggle* imageToggle, int button) override;
+    void imageButtonClicked(ImageButton* imageButton, int button) override;
 
     void onDisplay() override;
 
 private:
     Image fImgBackground;
-    ScopedPointer<ImageToggle> fToggleNoise;
+    ScopedPointer<ImageButton> fToggleNoise;
 };
 
 // -----------------------------------------------------------------------

--- a/plugins/ZamSFZ/ZamSFZPlugin.cpp
+++ b/plugins/ZamSFZ/ZamSFZPlugin.cpp
@@ -343,6 +343,11 @@ void ZamSFZPlugin::run(const float**, float** outputs, uint32_t frames,
   }
 }
 
+void ZamSFZPlugin::sampleRateChanged(double newSampleRate)
+{
+    // TODO reload file when sample rate changes
+}
+
 // -----------------------------------------------------------------------
 
 Plugin* createPlugin()

--- a/plugins/ZamSFZ/ZamSFZPlugin.hpp
+++ b/plugins/ZamSFZ/ZamSFZPlugin.hpp
@@ -120,9 +120,12 @@ protected:
     void activate() override;
     void run(const float** inputs, float** outputs, uint32_t frames,
     		const MidiEvent* midievent, uint32_t midicount) override;
+    void sampleRateChanged(double newSampleRate) override;
+
     void setState(const char* key, const char* value) override;
     String getState(const char* key) const override;
     void initState(unsigned int, String&, String&) override;
+
     // -------------------------------------------------------------------
 
 private:

--- a/plugins/ZamSFZ/ZamSFZUI.cpp
+++ b/plugins/ZamSFZ/ZamSFZUI.cpp
@@ -125,11 +125,11 @@ void ZamSFZUI::imageKnobValueChanged(ZamKnob* knob, float value)
 
 void ZamSFZUI::imageButtonClicked(ImageButton*, int)
 {
-    DGL::Window::FileBrowserOptions opts;
+    FileBrowserOptions opts;
     opts.title = "Load SFZ";
     //opts.filters = "sfz;";
 
-    getParentWindow().openFileBrowser(opts);
+    openFileBrowser(opts);
 }
 
 void ZamSFZUI::imageSwitchClicked(ImageSwitch*, bool state)
@@ -140,8 +140,10 @@ void ZamSFZUI::imageSwitchClicked(ImageSwitch*, bool state)
 
 void ZamSFZUI::onDisplay()
 {
-	fImgBackground.draw();
+	const GraphicsContext& context(getGraphicsContext());
+	fImgBackground.draw(context);
 }
+
 // -----------------------------------------------------------------------
 
 UI* createUI()

--- a/plugins/ZamSynth/ZamSynthPlugin.cpp
+++ b/plugins/ZamSynth/ZamSynthPlugin.cpp
@@ -42,6 +42,7 @@ ZamSynthPlugin::ZamSynthPlugin()
 
     curvoice = voice; //ptr to first voice
 
+    // TODO dynamic sample rate changes, while preserving user settings
     for (int i = 0; i < AREAHEIGHT; i++) {
         wave_y[i] = sin(i*2.*M_PI/getSampleRate());//*1000
     }
@@ -306,6 +307,10 @@ void ZamSynthPlugin::run(const float**, float** outputs, uint32_t frames,
 			outputs[1][i] = 0.f;
 		}
 	}
+}
+
+void ZamSynthPlugin::sampleRateChanged(double newSampleRate)
+{
 }
 
 // -----------------------------------------------------------------------

--- a/plugins/ZamSynth/ZamSynthPlugin.hpp
+++ b/plugins/ZamSynth/ZamSynthPlugin.hpp
@@ -115,8 +115,11 @@ protected:
     void activate() override;
     void run(const float** inputs, float** outputs, uint32_t frames,
     		const MidiEvent* midievent, uint32_t midicount) override;
+    void sampleRateChanged(double newSampleRate) override;
+
     void setState(const char* key, const char* value) override;
     void initState(unsigned int index, String& key, String& defval) override;
+
     // -------------------------------------------------------------------
 
 private:

--- a/plugins/ZamSynth/ZamSynthUI.cpp
+++ b/plugins/ZamSynth/ZamSynthUI.cpp
@@ -299,7 +299,8 @@ bool ZamSynthUI::onMotion(const MotionEvent& ev)
 
 void ZamSynthUI::onDisplay()
 {
-	fImgBackground.draw();
+    const GraphicsContext& context(getGraphicsContext());
+    fImgBackground.draw(context);
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/plugins/ZamVerb/ZamVerbPlugin.cpp
+++ b/plugins/ZamVerb/ZamVerbPlugin.cpp
@@ -216,6 +216,16 @@ void ZamVerbPlugin::run(const float** inputs, float** outputs, uint32_t frames)
 	}
 }
 
+void ZamVerbPlugin::bufferSizeChanged(uint32_t)
+{
+	reload();
+}
+
+void ZamVerbPlugin::sampleRateChanged(double)
+{
+	reload();
+}
+
 // -----------------------------------------------------------------------
 
 Plugin* createPlugin()

--- a/plugins/ZamVerb/ZamVerbPlugin.cpp
+++ b/plugins/ZamVerb/ZamVerbPlugin.cpp
@@ -196,8 +196,10 @@ void ZamVerbPlugin::run(const float** inputs, float** outputs, uint32_t frames)
 	float _wetdry = 0.01f * wetdry;
 
 	if (!signal) {
-		memcpy(outputs[0], inputs[0], frames * sizeof(float));
-		memcpy(outputs[1], inputs[1], frames * sizeof(float));
+		if (outputs[0] != inputs[0])
+			memcpy(outputs[0], inputs[0], frames * sizeof(float));
+		if (outputs[1] != inputs[1])
+			memcpy(outputs[1], inputs[1], frames * sizeof(float));
 		return;
 	}
 
@@ -206,8 +208,10 @@ void ZamVerbPlugin::run(const float** inputs, float** outputs, uint32_t frames)
 	memcpy(tmpins[1], inputs[1], frames * sizeof(float));
 	nprocessed = clv[active]->clv_convolve(tmpins, tmpouts, 2, 2, frames, from_dB(-16.f));
 	if (nprocessed <= 0) {
-		memcpy(outputs[0], inputs[0], frames * sizeof(float));
-		memcpy(outputs[1], inputs[1], frames * sizeof(float));
+		if (outputs[0] != inputs[0])
+			memcpy(outputs[0], inputs[0], frames * sizeof(float));
+		if (outputs[1] != inputs[1])
+			memcpy(outputs[1], inputs[1], frames * sizeof(float));
 	} else {
 		for (i = 0; i < frames; i++) {
 			outputs[0][i] = (_wetdry * tmpouts[0][i] + (1.f - _wetdry) * inputs[0][i]) * from_dB(master);

--- a/plugins/ZamVerb/ZamVerbPlugin.hpp
+++ b/plugins/ZamVerb/ZamVerbPlugin.hpp
@@ -114,6 +114,8 @@ protected:
     void activate() override;
     void deactivate() override;
     void run(const float** inputs, float** outputs, uint32_t frames) override;
+    void bufferSizeChanged(uint32_t newBufferSize) override;
+    void sampleRateChanged(double newSampleRate) override;
 
     LV2convolv *clv[2];
     int8_t swap;


### PR DESCRIPTION
I went through all the plugins that used `getSampleRate()` and `getBufferSize()`.
Fixed ZamNoise even though it is not enabled in the build yet, it needed a few tweaks to make it build with new DPF so I did the whole thing for it. For ZamSynth and ZamSFZ I left a TODO comment, those are more complex to handle and need more work anyhow.

Also fixed inline processing, in some hosts the audio buffer is reused and thus outputs == inputs
